### PR TITLE
Add a button which cleans up unused tags.

### DIFF
--- a/src/and/gen/bsoule/timepie/R.java
+++ b/src/and/gen/bsoule/timepie/R.java
@@ -31,11 +31,12 @@ public final class R {
         public static final int tplg=0x7f020011;
     }
     public static final class id {
-        public static final int ExportLink=0x7f050010;
-        public static final int Viewlog=0x7f05000f;
-        public static final int btnTog=0x7f05000e;
+        public static final int ExportLink=0x7f050011;
+        public static final int Viewlog=0x7f050010;
+        public static final int btnTog=0x7f05000f;
         public static final int btn_cancel=0x7f050001;
         public static final int btn_doit=0x7f050002;
+        public static final int cleanup_tags=0x7f05000d;
         public static final int confirm=0x7f050003;
         public static final int delete_data=0x7f05000c;
         public static final int delete_logs=0x7f05000b;
@@ -44,13 +45,13 @@ public final class R {
         public static final int lintags=0x7f050007;
         public static final int parent=0x7f050005;
         public static final int pingtime=0x7f050006;
-        public static final int row1=0x7f050011;
+        public static final int row1=0x7f050012;
         public static final int tag_button=0x7f050004;
         public static final int tags_editText=0x7f050008;
-        public static final int tpStat=0x7f05000d;
+        public static final int tpStat=0x7f05000e;
         public static final int txt_save=0x7f050000;
-        public static final int viewlog_row_tags=0x7f050013;
-        public static final int viewlog_row_time=0x7f050012;
+        public static final int viewlog_row_tags=0x7f050014;
+        public static final int viewlog_row_time=0x7f050013;
     }
     public static final class layout {
         public static final int delete_dialog=0x7f030000;

--- a/src/and/res/layout/timepie_export.xml
+++ b/src/and/res/layout/timepie_export.xml
@@ -35,5 +35,10 @@
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content">
 	</Button>
-		
+	<TextView android:layout_width="fill_parent"
+		android:layout_height="wrap_content" android:text="Manage tags:" />
+	<Button android:text="Remove unused tags" android:id="@+id/cleanup_tags"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content">
+	</Button>
 </LinearLayout>

--- a/src/and/src/bsoule/timepie/EditPing.java
+++ b/src/and/src/bsoule/timepie/EditPing.java
@@ -79,7 +79,7 @@ public class EditPing extends Activity {
 		mTaggings = mPingsDB.fetchTaggings(mRowId,PingsDbAdapter.KEY_PID);
 		startManagingCursor(mTaggings);
 
-		//Set confirm button behaviour:
+		// Set confirm button behaviour
 		Button confirm = (Button) findViewById(R.id.confirm);
 		confirm.setOnClickListener(	new OnClickListener() {
 			public void onClick(View v) {

--- a/src/and/src/bsoule/timepie/Export.java
+++ b/src/and/src/bsoule/timepie/Export.java
@@ -38,6 +38,7 @@ public class Export extends Activity {
 	private static final int DIALOG_DONE = 4;
 	private static final int DIALOG_DELETE_DATA = 5;
 	private static final int DIALOG_REALLY = 6;
+	private static final int DIALOG_CLEANUP_TAGS = 7;
 	private static final String FNAME = "timepie.log";
 
 	SharedPreferences mPrefs;
@@ -80,6 +81,12 @@ public class Export extends Activity {
 		doDeleteData.setOnClickListener(new OnClickListener() {
 			public void onClick(View v) {
 				showDialog(DIALOG_DELETE_DATA);
+			}
+		});
+		Button doCleanupTags = (Button) findViewById(R.id.cleanup_tags);
+		doCleanupTags.setOnClickListener(new OnClickListener() {
+			public void onClick(View v) {
+				showDialog(DIALOG_CLEANUP_TAGS);
 			}
 		});
 	}
@@ -127,6 +134,15 @@ public class Export extends Activity {
 					showDialog(DIALOG_DONE);
 				}
 			}).create();
+		case DIALOG_CLEANUP_TAGS:
+			return new AlertDialog.Builder(Export.this)
+			.setTitle("Clean up unused tags?")
+			.setPositiveButton("Clean", new DialogInterface.OnClickListener() {
+				public void onClick(DialogInterface dialog, int which) {
+					cleanupUnusedTags();
+					showDialog(DIALOG_DONE);
+				}
+			}).create();
 		}
 		AlertDialog.Builder adb = new AlertDialog.Builder(Export.this);
 		adb.setTitle(title);
@@ -136,6 +152,7 @@ public class Export extends Activity {
 		}).create();
 
 	}
+
 	private void deleteLogs() {
 		File log;
 		// delete log file from SD card provided it is mounted and file exists
@@ -166,6 +183,10 @@ public class Export extends Activity {
 		ed.remove(PingService.KEY_NEXT);
 		ed.remove(PingService.KEY_SEED);
 		ed.commit();
+	}
+
+	private void cleanupUnusedTags() {
+		mDb.cleanupUnusedTags();
 	}
 
 	private Dialog progressDialog() {

--- a/src/and/src/bsoule/timepie/PingsDbAdapter.java
+++ b/src/and/src/bsoule/timepie/PingsDbAdapter.java
@@ -364,4 +364,23 @@ public class PingsDbAdapter {
 		}
 		return true;
 	}
+	public void cleanupUnusedTags() {
+		Cursor c = fetchAllTags();
+		c.moveToFirst();
+		int idx = c.getColumnIndex(KEY_ROWID);
+		int tagIdx = c.getColumnIndex(KEY_TAG);
+		while (!c.isAfterLast()) {
+			long tid = c.getLong(idx);
+			Cursor tids = mDb.query(TAG_PING_TABLE, new String[] {KEY_ROWID}, KEY_TID + "=" + tid, null, null, null, null);
+			int usecount = tids.getCount();
+			tids.close();
+			Log.i(TAG, "tag " + c.getString(tagIdx) + " is used " + usecount + " times");
+			if (usecount == 0) {
+				Log.i(TAG, "removing tag " + c.getString(tagIdx) + " noone is using it.");
+				mDb.delete(TAGS_TABLE, KEY_ROWID + "=" + tid, null);
+			}
+			c.moveToNext();
+		}
+		c.close();
+	}
 }


### PR DESCRIPTION
I mistyped tags a bunch of times, and then accidently turned the phone back to portrait.  This left me with a bunch of tags that I didn't want to use cluttering up my tag screen.

This adds a button to the "Manage Data" screen which will remove tags from your screen that aren't in use at all.
