### PR TITLE
preferences: make gap time configurable

### DIFF
--- a/src/and/res/xml/preferences.xml
+++ b/src/and/res/xml/preferences.xml
@@ -32,5 +32,13 @@
 	    android:summaryOff="No flashing"
 	    android:summaryOn="LED will flash"
 	   /> 
+	  <EditTextPreference
+	    android:key="pingGap"
+	    android:title="Ping Frequency"
+	    android:defaultValue="45"
+	    android:inputType="number"
+	    android:summary="Average time between pings, in minutes."
+	   /> 
+
   </PreferenceCategory>
 </PreferenceScreen>

--- a/src/and/src/bsoule/tagtime/Constant.java
+++ b/src/and/src/bsoule/tagtime/Constant.java
@@ -1,5 +1,0 @@
-package bsoule.tagtime;
-
-public interface Constant {
-  public final static long GAP = 45*60;
-}


### PR DESCRIPTION
Instead of using a constant 45min gap, put it in the preferences.

This still needs some work: the change in gap time isn't reflected immediately, only after the next ping fires.
