### PR TITLE
preferences: added quiet-while-charging

### DIFF
--- a/src/and/res/xml/preferences.xml
+++ b/src/and/res/xml/preferences.xml
@@ -32,6 +32,13 @@
 	    android:summaryOff="No flashing"
 	    android:summaryOn="LED will flash"
 	   /> 
+	  <CheckBoxPreference
+	    android:key="pingQuietCharging"
+	    android:title="Quiet While Charging"
+	    android:defaultValue="false"
+	    android:summaryOff="Standard pings while charging."
+	    android:summaryOn="Silent pings while charging."
+	   /> 
 	  <EditTextPreference
 	    android:key="pingGap"
 	    android:title="Ping Frequency"


### PR DESCRIPTION
Adds a setting 'Quiet While Charging' that disables ringing and vibrating while the phone is plugged in.  This is intended for people who plug their phone in at night and don't want to be woken up.

This requires `BatteryManager.EXTRA_PLUGGED` which changes the minimum supported version from API 4 to [API 5](http://developer.android.com/sdk/api_diff/5/changes.html).  I think everyone should now be on Android 2.0 or later, so I think this is ok.
