### PR TITLE
Fix building app under Android Studio 3

### DIFF
--- a/src/and/README.md
+++ b/src/and/README.md
@@ -1,52 +1,13 @@
 # Getting Started
 
-To build the android app you first need to download and unpack the
-android sdk.  You can get that from http://developer.android.com/sdk
+To build the android app you first need to download and install Android Studio.  You can get that from http://developer.android.com/sdk
 
-You should now have a directory `sdk/tools` which contains an `android`
-binary.  Add `sdk/tools` to your path:
+You should now be able to run Android Studio. Do it.
 
-    $ export PATH="$PATH:/path/to/sdk/tools"
+Now you need to configure a target.  You can do this by clicking "SDK Manager" in the "Tools" menu.  Select Android 4.3, which is API Level 18.
 
-Now you need to configure a target.  To list available targets run:
-
-    $ android list targets
-
-By default this should have only one target, and it's probably for a
-more recent version of Android than your test device.  Open up the SDK
-Manager so you can install an older target:
-
-    $ android
-
-This should open up a GUI where you can download the files for an older
-version of Android.  `src/and/project.properties` has `target=android-4`
-so check the box next to "Android 1.6 (API 4)" and click the "Install
-Packages" button.
-
-After you accept the license it will sit there with a progress bar going
-through all the things it needs to download.  When it finishes quit the
-SDK Manager.
-
-Listing targets again you should now see one available like:
-
-    $ android list targets
-    Available Android targets:
-    ----------
-    id: 1 or "android-4"
-         Name: Android 1.6
-    ...
-
-Now we can configure our project to use this target:
-
-    $ cd TagTime/src/and
-    $ android update project --target android-4 --path .
-
-This makes lots of changes, but the important one is that it creates
-`build.xml` which allows you to run `ant`, which is kind of like `make`:
-
-    $ ant debug
-    [ lots of text ]
-    BUILD SUCCESSFUL
+After that it will sit there with a progress bar going
+through all the things it needs to download.
 
 To run it on your phone you first need to enable usb debugging.  If
 you're running something older than 4.0 it's under
@@ -59,26 +20,13 @@ With usb debugging enabled, plug the phone into your computer.  You
 should see a notification on the phone like "Android debugging
 enabled".
 
-We now need to run `adb` which is in `platform-tools` and not `tools`,
-so let's add it to the path:
-
-    $ export PATH="$PATH:/path/to/sdk/platform-tools"
-
-Now we can run the app on the phone for testing:
-
-    $ adb -d install bin/TPController-debug.apk
+Now return to Android Studio, and we can run the app on the phone for testing, by clicking "Run" in the "Run" menu.
 
 If you already have TagTime installed on your phone it won't work:
 
     Failure [INSTALL_FAILED_ALREADY_EXISTS]
 
 You need to back up your Tagtime data and uninstall Tagtime first,
-and then run the `adb` command again:
+and then click "Run" again.
 
-    $ adb -d install bin/TPController-debug.apk
-    Success
-
-Now you can go into Apps on your phone and start TagTime.
-
-Note: You will need the latest version of ActionBarSherlock to compile
-TagTime after recent updates.
+Note: You will need to disable Instant Run to compile TagTime. You can do that by going to Android Studio settings and disabling everything in "Build, Execution, Deployment / Instant Run".

--- a/src/and/build.gradle
+++ b/src/and/build.gradle
@@ -2,9 +2,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:3.1.2'
     }
 }
 

--- a/src/and/gradle.properties
+++ b/src/and/gradle.properties
@@ -1,0 +1,1 @@
+android.enableAapt2=false

--- a/src/and/gradle/wrapper/gradle-wrapper.properties
+++ b/src/and/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip

--- a/src/and/library/build.gradle
+++ b/src/and/library/build.gradle
@@ -1,8 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 16
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 18
 
     defaultConfig {
         minSdkVersion 8

--- a/src/and/tagTime/build.gradle
+++ b/src/and/tagTime/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 16
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 18
 
     defaultConfig {
         applicationId "bsoule.tagtime"
         minSdkVersion 8
-        targetSdkVersion 8
+        targetSdkVersion 18
     }
 
     buildTypes {


### PR DESCRIPTION
This PR allows to build TagTime under the latest stable version of Android Studio (3.1.2 as of now).

Here is what had to be done:
- Update gradle wrapper to 4.5
- Update gradle plugin to 3.1.2
- Disable aapt2 to fix a build error in ActionBarSherlock
- Upgrade `compileSdkVersion` to 18 to make it consistent with the version of the support library that was already in use
- Remove explicit `buildToolsVersion`. A default version is provided by recent gradle plugin versions.

NB: Running with instant run causes a build error from aapt. To fix that error, you'll have to disable instant run in Android Studio.