### PR TITLE
Add buttons to the notification for popular tags

### DIFF
--- a/src/and/build.gradle
+++ b/src/and/build.gradle
@@ -12,5 +12,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }

--- a/src/and/library/build.gradle
+++ b/src/and/library/build.gradle
@@ -1,5 +1,10 @@
 apply plugin: 'com.android.library'
 
+repositories {
+    jcenter()
+    google()
+}
+
 android {
     compileSdkVersion 18
 

--- a/src/and/tagTime/build.gradle
+++ b/src/and/tagTime/build.gradle
@@ -20,5 +20,5 @@ android {
 dependencies {
     compile project(':library')
     compile 'com.actionbarsherlock:actionbarsherlock:4.4.0@aar'
-    compile 'com.android.support:support-v4:21.+'
+    compile 'com.android.support:support-v4:21.0.3'
 }

--- a/src/and/tagTime/build.gradle
+++ b/src/and/tagTime/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 18
+    compileSdkVersion 21
 
     defaultConfig {
         applicationId "bsoule.tagtime"
         minSdkVersion 8
-        targetSdkVersion 18
+        targetSdkVersion 21
     }
 
     buildTypes {
@@ -20,5 +20,5 @@ android {
 dependencies {
     compile project(':library')
     compile 'com.actionbarsherlock:actionbarsherlock:4.4.0@aar'
-    compile 'com.android.support:support-v4:18.0.0'
+    compile 'com.android.support:support-v4:21.+'
 }

--- a/src/and/tagTime/src/main/AndroidManifest.xml
+++ b/src/and/tagTime/src/main/AndroidManifest.xml
@@ -63,6 +63,12 @@
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
+
+        <receiver
+            android:name=".SavePingReceiver"
+            android:enabled="true"
+            android:exported="false" />
+
     </application>
 
 </manifest>

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/EditPing.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/EditPing.java
@@ -300,6 +300,7 @@ public class EditPing extends SherlockActivity {
 		ll.setId(FIXTAGS);
 		ll.setOrientation(1);
 		ll.setLayoutParams(new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT));
+        String preselectTag = getIntent().getStringExtra(KEY_PRESELECT_TAG);
 		while (!mTagsCursor.isAfterLast()) {
 			String tag = mTagsCursor.getString(mTagsCursor.getColumnIndex(PingsDbAdapter.KEY_TAG));
 			long id = mTagsCursor.getLong(mTagsCursor.getColumnIndex(PingsDbAdapter.KEY_ROWID));
@@ -307,7 +308,9 @@ public class EditPing extends SherlockActivity {
 			if (mCurrentTags != null) on = mCurrentTags.contains(tag);
 			TagToggle tog = new TagToggle(this, tag, id, on);
 			tog.setOnClickListener(mTogListener);
-			tog.setChecked(tag.equals(getIntent().getStringExtra(KEY_PRESELECT_TAG)));
+            if (tag.equals(preselectTag)) {
+                tog.performClick();
+            }
 			ll.addView(tog);
 
 			mTagsCursor.moveToNext();

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/EditPing.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/EditPing.java
@@ -61,8 +61,6 @@ public class EditPing extends SherlockActivity {
 
 	public static final String KEY_TAGS = "tags";
 
-	static final String KEY_PRESELECT_TAG = "KEY_PRESELECT_TAG";
-
 	private PingsDbAdapter mPingsDB;
 	private Cursor mTagsCursor;
 
@@ -154,14 +152,12 @@ public class EditPing extends SherlockActivity {
 			mTagsEdit = (EditText) v;
 		}
 
-        // Cancel the notification:
-        // - The notification is auto-cancelling when clicked
-        // - But auto-cancel does not work if a notification action was clicked so in that case
-        // it has to be cancelled explicitly
-        NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-        assert nm != null;
-		boolean isFromNotifAction = getIntent().getStringExtra(KEY_PRESELECT_TAG) != null;
-		if (isFromNotifAction) nm.cancel(R.layout.tagtime_editping);
+		// cancel the notification
+		// TODO: only cancel note if it is for same ping as we are editing
+		// TODO: We could make the notification auto-cancelling when clicked.
+		// NotificationManager nm = (NotificationManager)
+		// getSystemService(NOTIFICATION_SERVICE);
+		// nm.cancel(R.layout.tagtime_editping);
 
 		mPingsDB = PingsDbAdapter.getInstance();
 		mPingsDB.openDatabase();
@@ -301,7 +297,6 @@ public class EditPing extends SherlockActivity {
 		ll.setId(FIXTAGS);
 		ll.setOrientation(1);
 		ll.setLayoutParams(new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT));
-        String preselectTag = getIntent().getStringExtra(KEY_PRESELECT_TAG);
 		while (!mTagsCursor.isAfterLast()) {
 			String tag = mTagsCursor.getString(mTagsCursor.getColumnIndex(PingsDbAdapter.KEY_TAG));
 			long id = mTagsCursor.getLong(mTagsCursor.getColumnIndex(PingsDbAdapter.KEY_ROWID));
@@ -309,9 +304,6 @@ public class EditPing extends SherlockActivity {
 			if (mCurrentTags != null) on = mCurrentTags.contains(tag);
 			TagToggle tog = new TagToggle(this, tag, id, on);
 			tog.setOnClickListener(mTogListener);
-            if (tag.equals(preselectTag)) {
-                tog.performClick();
-            }
 			ll.addView(tog);
 
 			mTagsCursor.moveToNext();

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/EditPing.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/EditPing.java
@@ -154,13 +154,13 @@ public class EditPing extends SherlockActivity {
 			mTagsEdit = (EditText) v;
 		}
 
-		// Cancel the notification:
-		// - The notification is auto-cancelling when clicked
-		// - But auto-cancel does not work if a notification action was clicked so in that case
-		// it has to be cancelled explicitly
-		// - Only cancel note if it is for same ping as we are editing, by using its rowId as a tag
-		NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-		nm.cancel(String.valueOf(mRowId), R.layout.tagtime_editping);
+        // Cancel the notification:
+        // - The notification is auto-cancelling when clicked
+        // - But auto-cancel does not work if a notification action was clicked so in that case
+        // it has to be cancelled explicitly
+        NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        assert nm != null;
+        nm.cancel(R.layout.tagtime_editping);
 
 		mPingsDB = PingsDbAdapter.getInstance();
 		mPingsDB.openDatabase();

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/EditPing.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/EditPing.java
@@ -160,7 +160,8 @@ public class EditPing extends SherlockActivity {
         // it has to be cancelled explicitly
         NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
         assert nm != null;
-        nm.cancel(R.layout.tagtime_editping);
+		boolean isFromNotifAction = getIntent().getStringExtra(KEY_PRESELECT_TAG) != null;
+		if (isFromNotifAction) nm.cancel(R.layout.tagtime_editping);
 
 		mPingsDB = PingsDbAdapter.getInstance();
 		mPingsDB.openDatabase();

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/EditPing.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/EditPing.java
@@ -61,6 +61,8 @@ public class EditPing extends SherlockActivity {
 
 	public static final String KEY_TAGS = "tags";
 
+	static final String KEY_PRESELECT_TAG = "KEY_PRESELECT_TAG";
+
 	private PingsDbAdapter mPingsDB;
 	private Cursor mTagsCursor;
 
@@ -304,6 +306,7 @@ public class EditPing extends SherlockActivity {
 			if (mCurrentTags != null) on = mCurrentTags.contains(tag);
 			TagToggle tog = new TagToggle(this, tag, id, on);
 			tog.setOnClickListener(mTogListener);
+			tog.setChecked(tag.equals(getIntent().getStringExtra(KEY_PRESELECT_TAG)));
 			ll.addView(tog);
 
 			mTagsCursor.moveToNext();

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/EditPing.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/EditPing.java
@@ -154,12 +154,13 @@ public class EditPing extends SherlockActivity {
 			mTagsEdit = (EditText) v;
 		}
 
-		// cancel the notification
-		// TODO: only cancel note if it is for same ping as we are editing
-		// TODO: We could make the notification auto-cancelling when clicked.
-		// NotificationManager nm = (NotificationManager)
-		// getSystemService(NOTIFICATION_SERVICE);
-		// nm.cancel(R.layout.tagtime_editping);
+		// Cancel the notification:
+		// - The notification is auto-cancelling when clicked
+		// - But auto-cancel does not work if a notification action was clicked so in that case
+		// it has to be cancelled explicitly
+		// - Only cancel note if it is for same ping as we are editing, by using its rowId as a tag
+		NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+		nm.cancel(String.valueOf(mRowId), R.layout.tagtime_editping);
 
 		mPingsDB = PingsDbAdapter.getInstance();
 		mPingsDB.openDatabase();

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
@@ -243,6 +243,22 @@ public class PingService extends Service {
 		);
 	}
 
+	private PendingIntent createBroadcastPendingIntent(long rowID, String tag) {
+
+		Intent editIntent = new Intent(this, SavePingReceiver.class);
+
+		editIntent.putExtra(PingsDbAdapter.KEY_ROWID, rowID);
+		editIntent.putExtra(PingsDbAdapter.KEY_TAG, tag);
+		editIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+		return PendingIntent.getBroadcast(
+				this,
+				tag == null ? 0 : tag.hashCode(),
+				editIntent,
+				PendingIntent.FLAG_CANCEL_CURRENT
+		);
+	}
+
 	/**
 	 * Add an action to a notification for each tag in the database. Handles
 	 * opening/closing DB too.
@@ -259,8 +275,9 @@ public class PingService extends Service {
 		while (!cursor.isAfterLast() && countActions++ < 3) {
 			int index = cursor.getColumnIndex(PingsDbAdapter.KEY_TAG);
 			String name = cursor.getString(index);
-			PendingIntent pendingIntent = createPendingIntent(rowId, name);
-			noteBuilder.addAction(0, name, pendingIntent);
+			PendingIntent pendingIntent = createBroadcastPendingIntent(rowId, name);
+			noteBuilder.addAction(0, name, pendingIntent)
+					.setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
 			cursor.moveToNext();
 		}
 		pingsDB.closeDatabase();

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
@@ -231,6 +231,7 @@ public class PingService extends Service {
 
 		editIntent.putExtra(PingsDbAdapter.KEY_ROWID, rowID);
 		editIntent.putExtra(PingsDbAdapter.KEY_TAG, tag);
+		editIntent.putExtra(EditPing.KEY_PRESELECT_TAG, tag);
 		editIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
 		return PendingIntent.getActivity(

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
@@ -232,7 +232,6 @@ public class PingService extends Service {
 
 		editIntent.putExtra(PingsDbAdapter.KEY_ROWID, rowID);
 		editIntent.putExtra(PingsDbAdapter.KEY_TAG, tag);
-		editIntent.putExtra(EditPing.KEY_PRESELECT_TAG, tag);
 		editIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
 		return PendingIntent.getActivity(

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
@@ -214,7 +214,7 @@ public class PingService extends Service {
 		// that gets assigned to the notification (we happen to pull it from a
 		// layout id
 		// so that we can cancel the notification later on).
-		NM.notify(PING_NOTES, note);
+		NM.notify(String.valueOf(rowID), PING_NOTES, note);
 
 	}
 

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
@@ -214,7 +214,8 @@ public class PingService extends Service {
 		// that gets assigned to the notification (we happen to pull it from a
 		// layout id
 		// so that we can cancel the notification later on).
-		NM.notify(String.valueOf(rowID), PING_NOTES, note);
+		assert NM != null;
+		NM.notify(PING_NOTES, note);
 
 	}
 

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
@@ -1,11 +1,5 @@
 package bsoule.tagtime;
 
-import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-
 import android.app.AlarmManager;
 import android.app.Notification;
 import android.app.NotificationManager;
@@ -23,13 +17,20 @@ import android.os.PowerManager;
 import android.os.RemoteException;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
+import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
-/* 
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+/*
  * the Ping service is in charge of maintaining random number
  * generator state on disk, sending ping notifications, and
  * setting ping alarms.
- * 
+ *
  */
 
 public class PingService extends Service {
@@ -160,7 +161,11 @@ public class PingService extends Service {
 		CharSequence text = getText(R.string.status_bar_notes_ping_msg);
 
 		// Set the icon, scrolling text, and timestamp.
-		Notification note = new Notification(R.drawable.stat_ping, text, ping.getTime());
+        Notification note = new NotificationCompat.Builder(getApplicationContext())
+                .setSmallIcon(R.drawable.stat_ping)
+                .setTicker(text)
+                .setWhen(ping.getTime())
+                .build();
 
 		// The PendingIntent to launch our activity if the user selects this
 		// notification

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/SavePingReceiver.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/SavePingReceiver.java
@@ -1,0 +1,43 @@
+package bsoule.tagtime;
+
+import android.app.NotificationManager;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.widget.Toast;
+
+import java.util.Collections;
+
+public class SavePingReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+
+        long rowId = intent.getLongExtra(PingsDbAdapter.KEY_ROWID, 0);
+        String tag = intent.getStringExtra(PingsDbAdapter.KEY_TAG);
+
+        if (rowId != 0 && tag != null) {
+            updateTagging(context, rowId, tag);
+            cancelNotif(context);
+        } else {
+            String msg = context.getString(R.string.ping_saving_failure, rowId, tag);
+            Toast.makeText(context, msg, Toast.LENGTH_LONG).show();
+        }
+    }
+
+    private void cancelNotif(Context context) {
+        NotificationManager notifManager =
+                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        assert notifManager != null;
+        notifManager.cancel(R.layout.tagtime_editping);
+    }
+
+    private void updateTagging(Context context, long rowId, String tag) {
+        PingsDbAdapter pingsDb = PingsDbAdapter.getInstance();
+        pingsDb.openDatabase();
+        pingsDb.updateTaggings(rowId, Collections.singletonList(tag));
+        String msg = context.getString(R.string.ping_saving_success, rowId, tag);
+        Toast.makeText(context, msg, Toast.LENGTH_LONG).show();
+        pingsDb.closeDatabase();
+    }
+}

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/SavePingReceiver.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/SavePingReceiver.java
@@ -18,11 +18,24 @@ public class SavePingReceiver extends BroadcastReceiver {
 
         if (rowId != 0 && tag != null) {
             updateTagging(context, rowId, tag);
+            beemindTag(context, rowId, tag);
             cancelNotif(context);
         } else {
             String msg = context.getString(R.string.ping_saving_failure, rowId, tag);
             Toast.makeText(context, msg, Toast.LENGTH_LONG).show();
         }
+    }
+
+    private void beemindTag(Context context, long rowId, String tag) {
+        if (rowId >= 0) {
+            Intent intent = new Intent(context, BeeminderService.class);
+            intent.setAction(BeeminderService.ACTION_EDITPING);
+            intent.putExtra(BeeminderService.KEY_PID, rowId);
+            intent.putExtra(BeeminderService.KEY_OLDTAGS, "");
+            intent.putExtra(BeeminderService.KEY_NEWTAGS, tag);
+            context.startService(intent);
+        }
+        TagTime.broadcastPingUpdate(false);
     }
 
     private void cancelNotif(Context context) {

--- a/src/and/tagTime/src/main/res/values/strings.xml
+++ b/src/and/tagTime/src/main/res/values/strings.xml
@@ -49,4 +49,7 @@
 	<string name="about_changelog">ChangeLog</string>
 	<string name="about_googleplay">Visit on Google Play</string>
 
+    <string name="ping_saving_success">Ping %1$d has been updated with tag %2$s</string>
+    <string name="ping_saving_failure">Ping %1$d could not be saved with tag %2$s</string>
+
 </resources>


### PR DESCRIPTION
This PR adds buttons to notifications, allowing to select a tag in one click for a ping.

The feature is intended to provide some support for smartwatches eg. Android Wear or Samsung Gear, as specified in #42.
I'm currently testing it on my Samsung Gear Sport watch running Tizen 3.0. 

Here is how it's done:
- Create a new broadcast receiver that attributes a tag to a given ping and then sends it to beeminder
- Implement notification actions for a ping by iterating on the most frequently used tags and then creating an action for each of these tags. Each action sends an intent that trigger the broadcast receiver with a given tag and ping ID.