### PR TITLE
Fix Doze

### DIFF
--- a/src/and/tagTime/build.gradle
+++ b/src/and/tagTime/build.gradle
@@ -20,5 +20,8 @@ android {
 dependencies {
     compile project(':library')
     compile 'com.actionbarsherlock:actionbarsherlock:4.4.0@aar'
-    compile 'com.android.support:support-v4:23.4.0'
+
+    // Stay in 22 as migration to 23 requires replacing ActionBarSherlock with ActionBarCompat
+    //noinspection GradleDependency,GradleCompatible
+    compile 'com.android.support:support-v4:22.2.1'
 }

--- a/src/and/tagTime/build.gradle
+++ b/src/and/tagTime/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
+    compileSdkVersion 23
 
     defaultConfig {
         applicationId "bsoule.tagtime"
         minSdkVersion 8
-        targetSdkVersion 21
+        targetSdkVersion 23
     }
 
     buildTypes {
@@ -20,5 +20,5 @@ android {
 dependencies {
     compile project(':library')
     compile 'com.actionbarsherlock:actionbarsherlock:4.4.0@aar'
-    compile 'com.android.support:support-v4:21.0.3'
+    compile 'com.android.support:support-v4:23.4.0'
 }

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
@@ -298,7 +298,7 @@ public class PingService extends Service {
 		PendingIntent pendingIntent = PendingIntent.getBroadcast(this, 0, alit, 0);
 
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-			alarum.setAndAllowWhileIdle(type, trigger, pendingIntent);
+			alarum.setExactAndAllowWhileIdle(type, trigger, pendingIntent);
 		} else {
 			alarum.set(type, trigger, pendingIntent);
 		}

--- a/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
+++ b/src/and/tagTime/src/main/java/bsoule/tagtime/PingService.java
@@ -12,6 +12,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.BatteryManager;
 import android.os.Binder;
+import android.os.Build;
 import android.os.IBinder;
 import android.os.Parcel;
 import android.os.PowerManager;
@@ -161,22 +162,25 @@ public class PingService extends Service {
 		Date ping = new Date(pingtime * 1000);
 		CharSequence text = getText(R.string.status_bar_notes_ping_msg);
 
+		PendingIntent contentIntent = createPendingIntent(rowID, null);
+
 		// Set the icon, scrolling text, and timestamp.
         NotificationCompat.Builder noteBuilder =
 				new NotificationCompat.Builder(getApplicationContext())
 						.setSmallIcon(R.drawable.stat_ping)
 						.setTicker(text)
+						.setContentTitle("Ping!")
+						.setContentText(SDF.format(ping))
+						.setContentIntent(contentIntent)
 						.setWhen(ping.getTime());
 
 		addTagActions(noteBuilder, rowID);
 
-		PendingIntent contentIntent = createPendingIntent(rowID, null);
-
 		// Set the info for the views that show in the notification panel.
 		// note.setLatestEventInfo(context, contentTitle, contentText,
 		// contentIntent)
+
 		Notification note = noteBuilder.build();
-		note.setLatestEventInfo(this, "Ping!", SDF.format(ping), contentIntent);
 
 		boolean suppress_noises = false;
 		if (mPrefs.getBoolean("pingQuietCharging", false)) {
@@ -287,7 +291,17 @@ public class PingService extends Service {
 		AlarmManager alarum = (AlarmManager) getSystemService(ALARM_SERVICE);
 		Intent alit = new Intent(this, TPStartUp.class);
 		alit.putExtra("ThisIntentIsTPStartUpClass", true);
-		alarum.set(AlarmManager.RTC_WAKEUP, PING * 1000, PendingIntent.getBroadcast(this, 0, alit, 0));
+
+		assert alarum != null;
+		int type = AlarmManager.RTC_WAKEUP;
+		long trigger = PING * 1000;
+		PendingIntent pendingIntent = PendingIntent.getBroadcast(this, 0, alit, 0);
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+			alarum.setAndAllowWhileIdle(type, trigger, pendingIntent);
+		} else {
+			alarum.set(type, trigger, pendingIntent);
+		}
 	}
 
 	private static final long IA = 16807;


### PR DESCRIPTION
This PR fixes Doze support in recent Android versions. Many pings were not notified and automatically tagged as OFF.

Summary of changes:

- Bump to SDK 23 to bring the new `NotificationManager` that supports Doze, fix related build errors. NB: 23 is the most recent version TagTime can support. If we try a more recent version, we will have to increase the minSdkVersion. 

- Use `setExactAndAllowWhileIdle()` to schedule notifications. This method allows notifications to pop up even when the device is in Doze mode.